### PR TITLE
Add info to §1. Design elements and principles, that specification does not define any value validation

### DIFF
--- a/interface-spec.html
+++ b/interface-spec.html
@@ -108,7 +108,7 @@
     <li>Interfaces may have additional implementation specific properties.</li>
     <li>
        We don't define any validation of given values (e.g. IRI, URI, CURIE). 
-       If an implementation enforces valid values, it should state details prominent for the user.
+       Implementations that apply validation should make this fact clear in their documentation.
     </li>
   </ul>
 

--- a/interface-spec.html
+++ b/interface-spec.html
@@ -108,7 +108,8 @@
     <li>Interfaces may have additional implementation specific properties.</li>
     <li>
        We don't define any validation of given values (e.g. IRI, URI, CURIE). 
-       If an implementation enforces valid values, it should state details prominent for the user.</li>
+       If an implementation enforces valid values, it should state details prominent for the user.
+    </li>
   </ul>
 
   <p>

--- a/interface-spec.html
+++ b/interface-spec.html
@@ -106,6 +106,9 @@
     </li>
     <li>Should allow "upgrading" a plain object into a fully functional triple</li>
     <li>Interfaces may have additional implementation specific properties.</li>
+    <li>
+       We don't define any validation of given values (e.g. IRI, URI, CURIE). 
+       If an implementation enforces valid values, it should state details prominent for the user.</li>
   </ul>
 
   <p>


### PR DESCRIPTION
## Why?

For some people it may be obvious, but if you not that familiar with the rdfjs specification, you may wonder if an implementation should implement *value validation* or not.

@bergos stated it [here](https://github.com/rdfjs/representation-task-force/issues/130#issuecomment-442227907) and for me as an implementer its very important to know that.

## What?

I added a point in `§1. Design elements and principles`, which says that specification does not define any validation. If you want to change the text, feel free.

*Ref https://github.com/rdfjs/representation-task-force/issues/130*