### PR TITLE
Clarify that returned `Terms` are novel

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,9 @@
     <li>Interfaces do <em>not</em> specify how instances are stored in memory.</li>
     <li>Interfaces mandate specific pre-defined methods such as <code>.equals()</code>.</li>
     <li>
+       Interfaces are not expected to expose internal objects or return the same object from sucessive calls. Callers shoud use the `Term.equals()` function instead of `===` or `==` to test for equivalence. 
+    </li>
+    <li>
       Factory functions (e.g., <code>quad()</code>) or methods (e.g.,
       <code>store.createQuad()</code>) create instances.
     </li>


### PR DESCRIPTION
for s a quad store with one triple,
## Triples are novel
``` javascript
s.getQuads()[0].equals(s.getQuads()[0]) // true
s.getQuads()[0] == s.getQuads()[0] // false
```
## Terms are novel
``` javascript
s.getQuads()[0].subject.equals(s.getQuads()[0].subject) // true
s.getQuads()[0].subject == s.getQuads()[0].subject // false
```