### PR TITLE
Added RDF* support with new QuadTerm interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
     <h3><dfn>Term</dfn> interface</h3>
 
     <pre class="idl">
-    interface Term {
+    interface mixin Term {
       attribute string termType;
       attribute string value;
       boolean equals(optional Term? other);
@@ -145,7 +145,7 @@
       <dfn>termType</dfn> contains a value that identifies the concrete interface of the term, since
       Term itself is not directly instantiated. Possible values include <code>"NamedNode"</code>,
       <code>"BlankNode"</code>, <code>"Literal"</code>, <code>"Variable"</code> and
-      <code>"DefaultGraph"</code>.
+      <code>"DefaultGraph"</code> and <code>"Quad"</code>.
     </p>
     <p>
       <dfn>value</dfn> is refined by each interface which extends Term.
@@ -170,11 +170,13 @@
     <h3><dfn>NamedNode</dfn> interface</h3>
 
     <pre class="idl">
-    interface NamedNode : Term {
+    interface NamedNode {
       attribute string termType;
       attribute string value;
       boolean equals(optional Term? other);
     };
+
+    NamedNode includes Term;
     </pre>
 
     <p>
@@ -195,11 +197,13 @@
     <h3><dfn>BlankNode</dfn> interface</h3>
 
     <pre class="idl">
-    interface BlankNode : Term {
+    interface BlankNode {
       attribute string termType;
       attribute string value;
       boolean equals(optional Term? other);
     };
+
+    BlankNode includes Term;
     </pre>
 
     <p>
@@ -222,13 +226,15 @@
     <h3><dfn>Literal</dfn> interface</h3>
 
     <pre class="idl">
-    interface Literal : Term {
+    interface Literal {
       attribute string termType;
       attribute string value;
       attribute string language;
       attribute NamedNode datatype;
       boolean equals(optional Term? other);
     };
+
+    Literal includes Term;
     </pre>
 
     <p>
@@ -265,11 +271,13 @@
     <h3><dfn>Variable</dfn> interface</h3>
 
     <pre class="idl">
-    interface Variable : Term {
+    interface Variable {
       attribute string termType;
       attribute string value;
       boolean equals(optional Term? other);
     };
+
+    Variable includes Term;
     </pre>
 
     <p>
@@ -291,11 +299,13 @@
     <h3><dfn>DefaultGraph</dfn> interface</h3>
 
     <pre class="idl">
-    interface DefaultGraph : Term {
+    interface DefaultGraph {
       attribute string termType;
       attribute string value;
       boolean equals(optional Term? other);
     };
+
+    DefaultGraph includes Term;
     </pre>
 
     <p>
@@ -365,6 +375,67 @@
     </p>
   </section>
 
+  <section data-dfn-for="QuadTerm">
+    <h3><dfn>QuadTerm</dfn> interface</h3>
+
+    <pre class="idl">
+    interface QuadTerm : Quad {
+      attribute string termType;
+      attribute string? value;
+      attribute Term subject;
+      attribute Term predicate;
+      attribute Term object;
+      attribute Term graph;
+      boolean equals(optional QuadTerm? other);
+    };
+
+    QuadTerm includes Term;
+    </pre>
+
+    <p>
+      <dfn>termType</dfn> contains the constant <code>"Quad"</code>.
+    </p>
+    <p>
+      <dfn>value</dfn> contains the constant <code>undefined</code>.
+    </p>
+    <p>
+      <dfn>subject</dfn> the subject, which is a <code>NamedNode</code>, <code>BlankNode</code>,
+      <code>Variable</code> or <code>QuadTerm</code>.
+    </p>
+    <p>
+      <dfn>predicate</dfn> the predicate, which is a <code>NamedNode</code> or
+      <code>Variable</code>.
+    </p>
+    <p>
+      <dfn>object</dfn> the object, which is a <code>NamedNode</code>, <code>Literal</code>,
+      <code>BlankNode</code> or <code>Variable</code>.
+    </p>
+    <p>
+      <dfn>graph</dfn> the named graph, which is a <code>DefaultGraph</code>,
+      <code>NamedNode</code>, <code>BlankNode</code> or <code>Variable</code>.
+    </p>
+    <p class="note">
+      <code>Triple</code> MUST be represented as <code>QuadTerm</code> with <code>graph</code> set
+      to a <code>DefaultGraph</code>
+    </p>
+    <p>
+      <dfn>equals()</dfn> returns <code>true</code>
+      when called with parameter <code>other</code>
+      on an object <code>quad</code> if
+      all of the conditions below hold:
+    </p>
+    <ul>
+      <li><code>other</code> is <em>neither</em> <code>null</code> nor <code>undefined</code>;</li>
+      <li><code>quad.subject.equals(other.subject)</code> evaluates to <code>true</code>;</li>
+      <li><code>quad.predicate.equals(other.predicate)</code> evaluates to <code>true</code>;</li>
+      <li><code>quad.object.equals(other.object)</code> evaluates to a <code>true</code>;</li>
+      <li><code>quad.graph.equals(other.graph)</code> evaluates to a <code>true</code>;</li>
+    </ul>
+    <p>
+      otherwise, it returns <code>false</code>.
+    </p>
+  </section>
+
   <section data-dfn-for="DataFactory">
     <h3><dfn>DataFactory</dfn> interface</h3>
 
@@ -375,9 +446,9 @@
       Literal literal(string value, optional (string or NamedNode) languageOrDatatype);
       Variable variable(string value);
       DefaultGraph defaultGraph();
-      Quad quad(Term subject, Term predicate, Term object, optional Term? graph);
+      (Quad or QuadTerm) quad(Term subject, Term predicate, Term object, optional Term? graph);
       Term fromTerm(Term original);
-      Quad fromQuad(Quad original);
+      (Quad or QuadTerm) fromQuad((Quad or QuadTerm) original);
     };
     </pre>
 
@@ -406,7 +477,7 @@
       <dfn>defaultGraph()</dfn> returns an instance of <code>DefaultGraph</code>.
     </p>
     <p>
-      <dfn>quad()</dfn>returns a new instance of <code>Quad</code>.
+      <dfn>quad()</dfn>returns a new instance of <code>Quad</code> or <code>QuadTerm</code>.
       If <code>graph</code> is <code>undefined</code> or <code>null</code>
       it MUST set <code>graph</code> to a <code>DefaultGraph</code>.
     </p>


### PR DESCRIPTION
This PR adds RDF* support with a new `QuadTerm` interface. The `Term` was changed to a mixin interface to allow the `QuadTerm` to inherit from `Quad` and also include the `Term` interface. All `Quad` types in the `DataFactory` have been replaced by a union type of `Quad` and `QuadTerm`.