### PR TITLE
Added RDF* support by extending Quad from Term

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,8 @@
     <p>
       <dfn>termType</dfn> contains a value that identifies the concrete interface of the term, since
       Term itself is not directly instantiated. Possible values include <code>"NamedNode"</code>,
-      <code>"BlankNode"</code>, <code>"Literal"</code>, <code>"Variable"</code> and
-      <code>"DefaultGraph"</code>.
+      <code>"BlankNode"</code>, <code>"Literal"</code>, <code>"Variable"</code>,
+      <code>"DefaultGraph"</code> and <code>"Quad"</code>.
     </p>
     <p>
       <dfn>value</dfn> is refined by each interface which extends Term.
@@ -319,7 +319,9 @@
     <h3><dfn>Quad</dfn> interface</h3>
 
     <pre class="idl">
-    interface Quad {
+    interface Quad : Term {
+      attribute string? termType;
+      attribute string? value;
       attribute Term subject;
       attribute Term predicate;
       attribute Term object;
@@ -329,8 +331,15 @@
     </pre>
 
     <p>
-      <dfn>subject</dfn> the subject, which is a <code>NamedNode</code>, <code>BlankNode</code> or
-      <code>Variable</code>.
+      <dfn>termType</dfn> contains the constant <code>"Quad"</code> or <code>undefined</code> if the
+      implementation does not support RDF*.
+    </p>
+    <p>
+      <dfn>value</dfn> contains the constant <code>undefined</code>.
+    </p>
+    <p>
+      <dfn>subject</dfn> the subject, which is a <code>NamedNode</code>, <code>BlankNode</code>,
+      <code>Variable</code> or <code>Quad</code>.
     </p>
     <p>
       <dfn>predicate</dfn> the predicate, which is a <code>NamedNode</code> or

--- a/index.html
+++ b/index.html
@@ -320,8 +320,8 @@
 
     <pre class="idl">
     interface Quad : Term {
-      attribute string? termType;
-      attribute string? value;
+      attribute string termType;
+      attribute string value;
       attribute Term subject;
       attribute Term predicate;
       attribute Term object;
@@ -331,11 +331,10 @@
     </pre>
 
     <p>
-      <dfn>termType</dfn> contains the constant <code>"Quad"</code> or <code>undefined</code> if the
-      implementation does not support RDF*.
+      <dfn>termType</dfn> contains the constant <code>"Quad"</code>.
     </p>
     <p>
-      <dfn>value</dfn> contains the constant <code>undefined</code>.
+      <dfn>value</dfn> contains an empty string as constant value.
     </p>
     <p>
       <dfn>subject</dfn> the subject, which is a <code>NamedNode</code>, <code>BlankNode</code>,


### PR DESCRIPTION
This PR adds RDF* support by extending Quad from Term.

Please leave feedback till 2020-07-21 if you request any changes.
Please vote till 2020-07-28 👍  if this PR should be merged or 👎  if you prefer a different approach.

Below is a comparison of the [composition PR](https://github.com/rdfjs/data-model-spec/pull/163) and this PR.

|                                                                 | Composition | Extension |
| --------------------------------------------------------------- | ----------- | --------- |
| Fully backwards compatible with current RDF/JS spec version     |             | ✅        |
| Follows RDF* idea that a quad is a term                         |             | ✅        |
| No optional fields                                              | ✅          | ✅         |
| Dynamically check RDF* support on a factory [1]                 | ✅          | ✅         |


The following points have been excluded as they are contrary to the concept of the RDF/JS specifications:

- Alignment to Jena [2]
- Directly compatible with non-RDF* factories [3]

[1] Support for RDF* can be detected with `quad.termType === 'Quad'` on a `Quad` object, but see also [3].
[2] RDF/JS specifications are defined to be idiomatic for JavaScript.
[3] The factory interface exists to have the possibility to pass a specific factory based on the application requirements to other libraries without the need to recreated the objects. The specification explicitly mentions implementation specific properties, but of course, this also applies to features defined in minor versions of the specification.